### PR TITLE
Optimize node edges

### DIFF
--- a/ql/QLinspector.ql
+++ b/ql/QLinspector.ql
@@ -74,9 +74,8 @@ private class Sanitizer extends Callable {
 
 
 query predicate edges(ControlFlowNode node1, ControlFlowNode node2) {
-    (node1.(MethodAccess).getMethod() = node2 and node2 instanceof RecursiveCallToDangerousMethod) or 
-    (node2.(MethodAccess).getEnclosingCallable() = node1 and node1 instanceof RecursiveCallToDangerousMethod)or 
-    (node1.(RecursiveCallToDangerousMethod).polyCalls(node2) and node2 instanceof RecursiveCallToDangerousMethod)
+    (node1.(MethodAccess).getMethod().getAPossibleImplementation() = node2 and node2 instanceof RecursiveCallToDangerousMethod) or 
+    (node2.(MethodAccess).getEnclosingCallable() = node1 and node1 instanceof RecursiveCallToDangerousMethod) 
 }
 
 predicate hasCalls(RecursiveCallToDangerousMethod c0, RecursiveCallToDangerousMethod c1) {


### PR DESCRIPTION
Hi:
I found some problems with the predicates in edges: https://github.com/synacktiv/QLinspector/blob/main/ql/QLinspector.ql#L77-L79

1. The first predicate is to obtain the edge from MethodAccess to Callable, denoted as e1
2. The second predicate is to obtain the edge from Callable to MethodAccess, denoted as e2
3. The third predicate is to obtain the edge from Callable to Callable, denoted as e3

But e1+e2 is essentially the same as e3, it will lead to many repeated results. 
So I delete the third predicate.
<img width="567" alt="image" src="https://github.com/synacktiv/QLinspector/assets/39485696/8d973f31-7b67-4a90-9264-1f27e769d6df">

I think this first predicate wants to get which MethodAccess is used to access the `RecursiveCallToDangerousMethod`, but it currently cannot handle the call of the interface object.

So I use `getAPossibleImplementation` of `Method` to get all implementation method to handle the interface object.